### PR TITLE
Add missing gdal library and dependence numpy

### DIFF
--- a/cm/requirements.txt
+++ b/cm/requirements.txt
@@ -16,4 +16,6 @@ six==1.10.0
 flasgger==0.9.0
 Pika==0.12.0
 amqp==2.2.2
+numpy
+gdal
 


### PR DESCRIPTION
I've noticed that the base module is using the gdal library in the calculation function. I think it is fine to have an example, but the library seems to be missing in the `requirements.txt` file.
The PR add just the gdal and the numpy libraries.