### PR TITLE
Remove unused import and use temporary directory instead of /var/ for testing

### DIFF
--- a/cm/tests/tests.py
+++ b/cm/tests/tests.py
@@ -1,10 +1,12 @@
+import tempfile
 import unittest
-from werkzeug.exceptions import NotFound
 from app import create_app
 import os.path
 from shutil import copyfile
 from .test_client import TestClient
-UPLOAD_DIRECTORY = '/var/hotmaps/cm_files_uploaded'
+
+UPLOAD_DIRECTORY = os.path.join(tempfile.gettempdir(),
+                                'hotmaps', 'cm_files_uploaded')
 
 if not os.path.exists(UPLOAD_DIRECTORY):
     os.makedirs(UPLOAD_DIRECTORY)


### PR DESCRIPTION
The default test directory where the data are uploaded is in `/var` unfortunately most of the time the user has not write access to this directory as normal user. Furthermore not all the platform have this folder available.

The PR change the default directory using the temporary directory that I think tha for the test it is acceptable.